### PR TITLE
[fix] astro implementation for form

### DIFF
--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,6 +1,10 @@
 import { useState } from 'preact/hooks';
 
-export default function ContactForm() {
+interface ContactFormProps {
+  accessKey: string;
+}
+
+export default function ContactForm({ accessKey }: ContactFormProps) {
   const [formSubmitted, setFormSubmitted] = useState(false);
   const [responseMessage, setResponseMessage] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -43,7 +47,7 @@ export default function ContactForm() {
           <input
             type="hidden"
             name="access_key"
-            value={import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY}
+            value={accessKey}
           />
           
           <input

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import ContactForm from '../components/ContactForm';
+
+const accessKey = import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY;
 ---
 
 <Layout title="Contact">
@@ -16,6 +18,6 @@ import ContactForm from '../components/ContactForm';
       Reach out here and we'll be in touch soon!
     </p>
 
-    <ContactForm client:load />
+    <ContactForm client:load accessKey={accessKey} />
   </div>
 </Layout>


### PR DESCRIPTION
# Fix: Pass Web3Forms Access Key as Prop to Client Component

## Problem

Contact form was failing with error:  
> "Form must include a 'form_id' (in path) or 'access_key' field"

![Screenshot of the contact form error](https://github.com/user-attachments/assets/91d5f1e6-899e-4cf2-9f4b-3d8a70799dc1)

## Root Cause

`import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY` doesn't work in client-side Preact components.  
Environment variables accessed via `import.meta.env` are only available during server-side rendering in Astro.

## Solution

Pass the access key as a prop from the server-side Astro page to the client-side Preact component.

## Changes

### `contact.astro`

- Read `PUBLIC_WEB3FORMS_ACCESS_KEY` in the frontmatter (server-side).
- Pass `accessKey` as a prop to `<ContactForm>`.

### `ContactForm.tsx`

- Added `ContactFormProps` interface with `accessKey: string`.
- Updated component to accept `accessKey` prop.
- Changed hidden input to use `value={accessKey}` instead of `import.meta.env`.

## Result

- ✅ Access key is now properly included in form submissions
- ✅ Contact form works correctly