### PR TITLE
[fix] Update workflow to set environment variable

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,18 +20,18 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      - name: Set env vars from secrets
-        run: |
-            echo "SLACK_WEBHOOK=${{ secrets.SLACK_WEBHOOK }}" >> $GITHUB_ENV
       - name: Install, build, and upload your site
         uses: withastro/action@v3
         with:
         #   path: dist # The root location of your Astro project inside the repository. (optional)
           node-version: 22 # The specific version of Node that should be used to build your site. Defaults to 20. (optional)
           package-manager: npm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        env:
+          PUBLIC_WEB3FORMS_ACCESS_KEY: ${{ vars.PUBLIC_WEB3FORMS_ACCESS_KEY }}
 
   deploy:
     needs: build

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -3,6 +3,7 @@ import Layout from '../layouts/Layout.astro';
 import ContactForm from '../components/ContactForm';
 
 const accessKey = import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY;
+console.log('Access key defined:', !!accessKey, 'Length:', accessKey?.length, 'First 8 chars:', accessKey?.substring(0, 8));
 ---
 
 <Layout title="Contact">
@@ -18,6 +19,6 @@ const accessKey = import.meta.env.PUBLIC_WEB3FORMS_ACCESS_KEY;
       Reach out here and we'll be in touch soon!
     </p>
 
-    <ContactForm client:load accessKey={accessKey} />
+    <ContactForm client:load accessKey={accessKey} data-has-key={!!accessKey} data-key-preview={accessKey?.substring(0, 8)} />
   </div>
 </Layout>


### PR DESCRIPTION
## Fix GitHub Pages deployment environment variable configuration

### Problem
Contact form was failing in GitHub Pages deployment with "Form must include 'access_key' field" error due to missing environment variable during build.

### Changes
1. **Updated GitHub Actions workflow** (`.github/workflows/deploy.yml`):
   - Added `environment: github-pages` to build job to access environment variables
   - Removed obsolete `SLACK_WEBHOOK` configuration
   - Added `env` section to pass `PUBLIC_WEB3FORMS_ACCESS_KEY` to the build process

2. **Added debug logging** (`src/pages/contact.astro`):
   - Temporary console.log to verify access key is set during build
   - Added data attributes to form for client-side verification

### Setup Required
Add environment variable in GitHub repository:
- Go to: Settings → Environments → github-pages → Environment variables
- Add: `PUBLIC_WEB3FORMS_ACCESS_KEY` = `XXX`

### Verification
After deployment, check:
- GitHub Actions build logs for console.log output
- Inspect form element in browser for `data-has-key` and `data-key-preview` attributes
- Test contact form submission on live site