### PR TITLE
Enhance ShowArtwork component layout and add blog link in Layout

### DIFF
--- a/src/components/ShowArtwork.astro
+++ b/src/components/ShowArtwork.astro
@@ -6,18 +6,22 @@ export interface Props {
 const { image } = Astro.props;
 ---
 
-<div class="px-4 sm:px-6 md:px-4 lg:px-16">
+<div class="px-4 sm:px-6 md:px-4 lg:px-16 relative">
+  <a
+    href="/"
+    data-astro-reload
+    class="absolute inset-0 z-50"
+    aria-label="Homepage"
+  ></a>
   <div class="atropos show-art">
     <div class="atropos-scale">
       <div class="atropos-rotate">
         <div class="atropos-inner">
-          <a
-            href="/"
+          <div
             class="relative mx-auto block w-48 overflow-hidden rounded-lg sm:w-64 sm:rounded-xl lg:w-auto lg:rounded-2xl"
-            aria-label="Homepage"
           >
             <img class="w-full" src={image} alt="" />
-          </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -228,7 +228,10 @@ const keywords = [
 
           <div class="px-4 sm:px-6 md:px-4 lg:px-16">
             <p class="mt-2 text-center text-lg lg:text-left font-bold underline">
-              <a href="https://discord.gg/d9gZyYuqKd" target="_blank" rel="noopener noreferrer">Join our Discord Server!</a>
+              <a href="https://discord.gg/d9gZyYuqKd" target="_blank" rel="noopener noreferrer">Join our Discord Server</a>
+            </p>
+            <p class="mt-2 text-center text-lg lg:text-left font-bold underline">
+              <a href="/blog">Check out our blog</a>
             </p>
           </div>
 


### PR DESCRIPTION
1. We did not have a link to our blog easily accessible in mobile view without scrolling to the bottom of our episode list (which is now quite long 🙃) so we're adding one below the discord server CTA 
2. The image href for the home page was not working; we are fixing the CSS to make the full div clickable and at the correct z-index to play nice with the animation library